### PR TITLE
Ensure floating IP is not destroyed if droplet needs recreating

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
             cypress/screenshots/**/*.png
 
   build:
-    if: ${{ github.ref=='refs/heads/master' }}
+    if: ${{ github.ref=='refs/heads/master' || github.ref=='refs/heads/bugfix/floating-ip-not-very-floaty'}}
     needs:
       - test
       - svelte-check
@@ -107,7 +107,7 @@ jobs:
       IMAGE_NAME: sveltekit
 
   pulumi-preview:
-    if: ${{ github.ref != 'refs/heads/master' }}
+    if: ${{ github.ref != 'refs/heads/master' || github.ref=='refs/heads/bugfix/floating-ip-not-very-floaty'}}
     name: Preview infrastructure updates
     runs-on: ubuntu-latest
     steps:
@@ -141,7 +141,7 @@ jobs:
       ip: ${{ steps.update.outputs.ip }}
     steps:
       - name: Set env to develop
-        if: endsWith(github.ref, '/sveltekit-beta')
+        if: endsWith(github.ref, '/bugfix/floating-ip-not-very-floaty')
         run: echo "ENVIRONMENT=dev" >> $GITHUB_ENV
       - name: Set env to production
         if: endsWith(github.ref, '/master')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
             cypress/screenshots/**/*.png
 
   build:
-    if: ${{ github.ref=='refs/heads/master' || github.ref=='refs/heads/bugfix/floating-ip-not-very-floaty'}}
+    if: ${{ github.ref=='refs/heads/master' }}
     needs:
       - test
       - svelte-check
@@ -107,7 +107,7 @@ jobs:
       IMAGE_NAME: sveltekit
 
   pulumi-preview:
-    if: ${{ github.ref != 'refs/heads/master' || github.ref=='refs/heads/bugfix/floating-ip-not-very-floaty'}}
+    if: ${{ github.ref != 'refs/heads/master' }}
     name: Preview infrastructure updates
     runs-on: ubuntu-latest
     steps:
@@ -141,7 +141,7 @@ jobs:
       ip: ${{ steps.update.outputs.ip }}
     steps:
       - name: Set env to develop
-        if: endsWith(github.ref, '/bugfix/floating-ip-not-very-floaty')
+        if: "!endsWith(github.ref, '/master')"
         run: echo "ENVIRONMENT=dev" >> $GITHUB_ENV
       - name: Set env to production
         if: endsWith(github.ref, '/master')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,16 @@ jobs:
         run: |
           npm ci
           npm run svelte-check
-  unique_id:
-    name: "Generate unique ID for workflow run"
+  nonce:
     runs-on: ubuntu-latest
-    steps:
-      - name: Generate unique id
-        id: unique_id
-        run: echo "::set-output name=id::$(uuidgen)"
+    # persist job results to other jobs in the workflow
     outputs:
-      unique_id: ${{ steps.unique_id.outputs.id }}
+      result: ${{ steps.nonce.outputs.result }}
+    steps:
+      # persist step results to other steps in the job
+      - id: nonce
+        # adding a timestamp makes the nonce more unique for re-runs
+        run: echo "::set-output name=result::${{ github.run_id }}-$(date +%s)"
   test:
     name: Cypress run
     runs-on: ubuntu-latest
@@ -43,7 +44,7 @@ jobs:
         # run 4 copies of the current job in parallel
         containers: [1, 2, 3, 4]
     needs:
-      - unique_id
+      - nonce
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -67,8 +68,8 @@ jobs:
           # See https://dev.to/digitaledawn/github-action-cypress-and-percy-parallelisation-setup-484a for percy setup
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_TOTAL: 4
-          # We need a uuid (as mentioned here https://github.com/actions/toolkit/issues/65#issuecomment-718134668) to uniquely identify re-runs)
-          PERCY_PARALLEL_NONCE: "${{ github.event_name }}-${{ github.sha }}-${{ needs.unique_id.outputs.unique_id }}"
+          # Use the generated nonce to distinguish between runs (as shown in example here: https://docs.percy.io/docs/parallel-test-suites#github-actions)
+          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}
           PERCY_BRANCH: ${{ github.head_ref }}
           COMMIT_INFO_BRANCH: ${{ github.head_ref }}
       - name: Upload artifacts

--- a/deploy/pulumi/index.js
+++ b/deploy/pulumi/index.js
@@ -52,7 +52,7 @@ const floatingIP = new digitalocean.FloatingIp("website-ip", {
 // Assign it to the droplet separately so we don't recreate it if
 const floatingIPAssignment = new digitalocean.FloatingIpAssignment("website-ip-assignment", {
   ipAddress: floatingIP.ipAddress,
-  dropletId: web.dropletId,
+  dropletId: web.id,
 });
 
 let domain;

--- a/deploy/pulumi/index.js
+++ b/deploy/pulumi/index.js
@@ -19,10 +19,12 @@ if (stack === "shared") {
 
 const shared = new pulumi.StackReference("cucb/cucb-website/shared");
 
+const region = "lon1";
+
 // A droplet to host the site
 const web = new digitalocean.Droplet("website", {
   image: "ubuntu-20-04-x64",
-  region: "lon1",
+  region,
   size: "s-1vcpu-1gb",
   backups: true,
   name: `website-${stack}`,
@@ -31,7 +33,7 @@ const web = new digitalocean.Droplet("website", {
 
 // Block storage for a first tier backup (in addition to dropbox)
 const webBlock = new digitalocean.Volume("website-block", {
-  region: "lon1",
+  region,
   size: 5,
   initialFilesystemType: "ext4",
   description: "Volume for database backups and user uploads",
@@ -46,14 +48,14 @@ const webBlockAttachment = new digitalocean.VolumeAttachment("website-block-atta
 
 // Create a floating ip so we have somewhere to point dns to even if the droplet is destroyed
 const floatingIP = new digitalocean.FloatingIp("website-ip", {
-  region: web.region,
+  region,
 });
 
 // Assign it to the droplet separately so we don't recreate it if
 const floatingIPAssignment = new digitalocean.FloatingIpAssignment("website-ip-assignment", {
   ipAddress: floatingIP.ipAddress,
-  // Use parseInt as a workaround for https://github.com/pulumi/pulumi-digitalocean/issues/218
-  dropletId: parseInt(web.id),
+  // Use .apply(parseInt) as a workaround for https://github.com/pulumi/pulumi-digitalocean/issues/218
+  dropletId: web.id.apply(parseInt),
 });
 
 let domain;

--- a/deploy/pulumi/index.js
+++ b/deploy/pulumi/index.js
@@ -47,7 +47,12 @@ const webBlockAttachment = new digitalocean.VolumeAttachment("website-block-atta
 // Create a floating ip so we have somewhere to point dns to even if the droplet is destroyed
 const floatingIP = new digitalocean.FloatingIp("website-ip", {
   region: web.region,
-  dropletId: web.id.apply(parseInt),
+});
+
+// Assign it to the droplet separately so we don't recreate it if
+const floatingIPAssignment = new digitalocean.FloatingIpAssignment("website-ip-assignment", {
+  ipAddress: floatingIP.ipAddress,
+  dropletId: web.dropletId,
 });
 
 let domain;

--- a/deploy/pulumi/index.js
+++ b/deploy/pulumi/index.js
@@ -52,7 +52,8 @@ const floatingIP = new digitalocean.FloatingIp("website-ip", {
 // Assign it to the droplet separately so we don't recreate it if
 const floatingIPAssignment = new digitalocean.FloatingIpAssignment("website-ip-assignment", {
   ipAddress: floatingIP.ipAddress,
-  dropletId: web.id,
+  // Use parseInt as a workaround for https://github.com/pulumi/pulumi-digitalocean/issues/218
+  dropletId: parseInt(web.id),
 });
 
 let domain;

--- a/deploy/pulumi/package-lock.json
+++ b/deploy/pulumi/package-lock.json
@@ -7,7 +7,7 @@
       "name": "cucb-website",
       "dependencies": {
         "@pulumi/cloudflare": "^4.0.0",
-        "@pulumi/digitalocean": "^4.7.0",
+        "@pulumi/digitalocean": "^4.10.0",
         "@pulumi/pulumi": "^3.15.0"
       }
     },
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@pulumi/digitalocean": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@pulumi/digitalocean/-/digitalocean-4.7.0.tgz",
-      "integrity": "sha512-2zFLFP0SIHFrEw2WdOyC3bYI3trcU4VDC/AvXhoDDWNoG/ZM2EiWvdFbzn6ThtkyPWjA4+eXjuaay6VxXNHERw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/digitalocean/-/digitalocean-4.10.0.tgz",
+      "integrity": "sha512-75IJokW09FOKwqsNEVQ8KaDBmrsBfSteS/gjSDXDsDSRlOv8E2WS2+sjwIzXzUxsptxn+37wx9gCUh/R39MFtQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
@@ -1114,9 +1114,9 @@
       }
     },
     "@pulumi/digitalocean": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@pulumi/digitalocean/-/digitalocean-4.7.0.tgz",
-      "integrity": "sha512-2zFLFP0SIHFrEw2WdOyC3bYI3trcU4VDC/AvXhoDDWNoG/ZM2EiWvdFbzn6ThtkyPWjA4+eXjuaay6VxXNHERw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/digitalocean/-/digitalocean-4.10.0.tgz",
+      "integrity": "sha512-75IJokW09FOKwqsNEVQ8KaDBmrsBfSteS/gjSDXDsDSRlOv8E2WS2+sjwIzXzUxsptxn+37wx9gCUh/R39MFtQ==",
       "requires": {
         "@pulumi/pulumi": "^3.0.0",
         "builtin-modules": "3.0.0",

--- a/deploy/pulumi/package.json
+++ b/deploy/pulumi/package.json
@@ -3,7 +3,7 @@
   "main": "index.js",
   "dependencies": {
     "@pulumi/cloudflare": "^4.0.0",
-    "@pulumi/digitalocean": "^4.7.0",
+    "@pulumi/digitalocean": "^4.10.0",
     "@pulumi/pulumi": "^3.15.0"
   }
 }


### PR DESCRIPTION
When I accidentally destroyed the prod droplet the other day trying to share data between stacks, the floating IP got taken with it (which defeats the purpose of having a floating IP in the first place). This change prevents the floating IP from depending on the output of the droplet, so the IP does not change if the droplet is recreated.